### PR TITLE
chore: ignore swig jni file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -453,3 +453,6 @@ dask-worker-space/
 *.pub
 *.rdp
 *_rsa
+
+# swig jni
+*_swig.jnilib


### PR DESCRIPTION
remnants from running make w `DUSE_SWIG=on`